### PR TITLE
Add responsive hamburger navigation for mobile

### DIFF
--- a/autobiography.html
+++ b/autobiography.html
@@ -15,9 +15,14 @@
 </head>
 <body>
     <header class="banner container-fluid">
-        <div class="container d-flex justify-content-between align-items-center">
+        <div class="container header-content">
             <h1 class="text-center fw-bold fs-4 m-0">My Homepage</h1>
-            <nav class="d-flex align-items-center">
+            <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-navigation">
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+            </button>
+            <nav id="primary-navigation" class="site-nav">
                 <a href="index.html" class="px-2">Home</a>
                 <a href="autobiography.html" class="px-2">Autobiography</a>
                 <a href="me-or-not-me.html" class="px-2">Me or Not Me?</a>
@@ -67,5 +72,44 @@
             Every day brings new adventures, and I can't wait to see what the future holds.
         </p>
     </main>
+    <script>
+        // Toggle the visibility of the navigation for smaller screens.
+        document.addEventListener('DOMContentLoaded', function () {
+            var toggleButton = document.querySelector('.nav-toggle');
+            var navigation = document.getElementById('primary-navigation');
+
+            if (!toggleButton || !navigation) {
+                return;
+            }
+
+            toggleButton.addEventListener('click', function () {
+                var isExpanded = toggleButton.getAttribute('aria-expanded') === 'true';
+                toggleButton.setAttribute('aria-expanded', (!isExpanded).toString());
+                navigation.classList.toggle('is-open', !isExpanded);
+            });
+
+            navigation.querySelectorAll('a, button').forEach(function (interactiveElement) {
+                interactiveElement.addEventListener('click', function () {
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                    navigation.classList.remove('is-open');
+                });
+            });
+
+            var desktopMediaQuery = window.matchMedia('(min-width: 769px)');
+
+            var handleViewportChange = function (event) {
+                if (event.matches) {
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                    navigation.classList.remove('is-open');
+                }
+            };
+
+            if (typeof desktopMediaQuery.addEventListener === 'function') {
+                desktopMediaQuery.addEventListener('change', handleViewportChange);
+            } else if (typeof desktopMediaQuery.addListener === 'function') {
+                desktopMediaQuery.addListener(handleViewportChange);
+            }
+        });
+    </script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -15,9 +15,14 @@
 </head>
 <body>
     <header class="banner container-fluid">
-        <div class="container d-flex justify-content-between align-items-center">
+        <div class="container header-content">
             <h1 class="text-center fw-bold fs-4 m-0">My Homepage</h1>
-            <nav class="d-flex align-items-center">
+            <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-navigation">
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+            </button>
+            <nav id="primary-navigation" class="site-nav">
                 <a href="index.html" class="px-2">Home</a>
                 <a href="autobiography.html" class="px-2">Autobiography</a>
                 <a href="me-or-not-me.html" class="px-2">Me or Not Me?</a>
@@ -34,5 +39,44 @@
             <li><h5 class="mt-3"><a href="https://www.instagram.com/sm__sydney/">Instagram</a></h5></li>
         </ul>
     </main>
+    <script>
+        // Toggle the visibility of the navigation for smaller screens.
+        document.addEventListener('DOMContentLoaded', function () {
+            var toggleButton = document.querySelector('.nav-toggle');
+            var navigation = document.getElementById('primary-navigation');
+
+            if (!toggleButton || !navigation) {
+                return;
+            }
+
+            toggleButton.addEventListener('click', function () {
+                var isExpanded = toggleButton.getAttribute('aria-expanded') === 'true';
+                toggleButton.setAttribute('aria-expanded', (!isExpanded).toString());
+                navigation.classList.toggle('is-open', !isExpanded);
+            });
+
+            navigation.querySelectorAll('a, button').forEach(function (interactiveElement) {
+                interactiveElement.addEventListener('click', function () {
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                    navigation.classList.remove('is-open');
+                });
+            });
+
+            var desktopMediaQuery = window.matchMedia('(min-width: 769px)');
+
+            var handleViewportChange = function (event) {
+                if (event.matches) {
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                    navigation.classList.remove('is-open');
+                }
+            };
+
+            if (typeof desktopMediaQuery.addEventListener === 'function') {
+                desktopMediaQuery.addEventListener('change', handleViewportChange);
+            } else if (typeof desktopMediaQuery.addListener === 'function') {
+                desktopMediaQuery.addListener(handleViewportChange);
+            }
+        });
+    </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,9 +15,14 @@
 </head>
 <body>
     <header class="banner container-fluid">
-        <div class="container d-flex justify-content-between align-items-center">
+        <div class="container header-content">
             <h1 class="text-center fw-bold fs-4 m-0">My Homepage</h1>
-            <nav class="d-flex align-items-center">
+            <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-navigation">
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+            </button>
+            <nav id="primary-navigation" class="site-nav">
                 <a href="index.html" class="px-2">Home</a>
                 <a href="autobiography.html" class="px-2">Autobiography</a>
                 <a href="me-or-not-me.html" class="px-2">Me or Not Me?</a>
@@ -32,5 +37,44 @@
         <h3 class="fw-bold mt-4">Introduction</h3>
         <p class="mt-3">Hello, My name is Sydney. Welcome to My Homepage! This is a place where you can learn more about me and my journey. Enjoy exploring!</p>
     </main>
+    <script>
+        // Toggle the visibility of the navigation for smaller screens.
+        document.addEventListener('DOMContentLoaded', function () {
+            var toggleButton = document.querySelector('.nav-toggle');
+            var navigation = document.getElementById('primary-navigation');
+
+            if (!toggleButton || !navigation) {
+                return;
+            }
+
+            toggleButton.addEventListener('click', function () {
+                var isExpanded = toggleButton.getAttribute('aria-expanded') === 'true';
+                toggleButton.setAttribute('aria-expanded', (!isExpanded).toString());
+                navigation.classList.toggle('is-open', !isExpanded);
+            });
+
+            navigation.querySelectorAll('a, button').forEach(function (interactiveElement) {
+                interactiveElement.addEventListener('click', function () {
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                    navigation.classList.remove('is-open');
+                });
+            });
+
+            var desktopMediaQuery = window.matchMedia('(min-width: 769px)');
+
+            var handleViewportChange = function (event) {
+                if (event.matches) {
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                    navigation.classList.remove('is-open');
+                }
+            };
+
+            if (typeof desktopMediaQuery.addEventListener === 'function') {
+                desktopMediaQuery.addEventListener('change', handleViewportChange);
+            } else if (typeof desktopMediaQuery.addListener === 'function') {
+                desktopMediaQuery.addListener(handleViewportChange);
+            }
+        });
+    </script>
 </body>
 </html>

--- a/me-or-not-me.html
+++ b/me-or-not-me.html
@@ -151,9 +151,14 @@
 </head>
 <body>
     <header class="banner container-fluid">
-        <div class="container d-flex justify-content-between align-items-center">
+        <div class="container header-content">
             <h1 class="text-center fw-bold fs-4 m-0">My Homepage</h1>
-            <nav class="d-flex align-items-center">
+            <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-navigation">
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+                <span class="nav-toggle-bar"></span>
+            </button>
+            <nav id="primary-navigation" class="site-nav">
                 <a href="index.html" class="px-2">Home</a>
                 <a href="autobiography.html" class="px-2">Autobiography</a>
                 <a href="me-or-not-me.html" class="px-2">Me or Not Me?</a>
@@ -209,5 +214,44 @@
             <p id="sum" class="fw-bold"></p>
         </div>
     </main>
+    <script>
+        // Toggle the visibility of the navigation for smaller screens.
+        document.addEventListener('DOMContentLoaded', function () {
+            var toggleButton = document.querySelector('.nav-toggle');
+            var navigation = document.getElementById('primary-navigation');
+
+            if (!toggleButton || !navigation) {
+                return;
+            }
+
+            toggleButton.addEventListener('click', function () {
+                var isExpanded = toggleButton.getAttribute('aria-expanded') === 'true';
+                toggleButton.setAttribute('aria-expanded', (!isExpanded).toString());
+                navigation.classList.toggle('is-open', !isExpanded);
+            });
+
+            navigation.querySelectorAll('a, button').forEach(function (interactiveElement) {
+                interactiveElement.addEventListener('click', function () {
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                    navigation.classList.remove('is-open');
+                });
+            });
+
+            var desktopMediaQuery = window.matchMedia('(min-width: 769px)');
+
+            var handleViewportChange = function (event) {
+                if (event.matches) {
+                    toggleButton.setAttribute('aria-expanded', 'false');
+                    navigation.classList.remove('is-open');
+                }
+            };
+
+            if (typeof desktopMediaQuery.addEventListener === 'function') {
+                desktopMediaQuery.addEventListener('change', handleViewportChange);
+            } else if (typeof desktopMediaQuery.addListener === 'function') {
+                desktopMediaQuery.addListener(handleViewportChange);
+            }
+        });
+    </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,7 @@ body {
 /* Banner Styling */
 .banner {
   background: linear-gradient(to right, #eef2ff, #fffbea);
-  height: 55px; /* Set a fixed height for the banner */
+  min-height: 55px; /* Allow the banner to grow when the menu is expanded */
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -18,6 +18,50 @@ body {
   position: sticky; /* Ensure that banner still visible even after user scroll down */
   top: 0;
   z-index: 1000; /* Ensure banner is on top */
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 1rem;
+  position: relative;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.site-nav a {
+  padding: 0.25rem 0.5rem;
+}
+
+.nav-toggle {
+  display: none; /* Hidden on larger screens */
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.35rem;
+  background: transparent;
+  border: none;
+  padding: 0.35rem;
+  cursor: pointer;
+}
+
+.nav-toggle:focus {
+  outline: 2px solid #0073e6;
+  outline-offset: 2px;
+}
+
+.nav-toggle-bar {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background-color: #333;
+  border-radius: 2px;
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 
@@ -69,7 +113,7 @@ body {
 
 a {
   color: #4c4848;
-  transition: color 0.3s ease; 
+  transition: color 0.3s ease;
   text-decoration: none;
 }
 
@@ -97,6 +141,45 @@ a:hover {
 
 .option:hover {
   background-color: #a6a4a4;
+}
+
+@media (max-width: 768px) {
+  .banner {
+    padding: 0.75rem 1.25rem;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .site-nav {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    display: none;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.96);
+    padding: 1rem 1.25rem;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
+  }
+
+  .site-nav.is-open {
+    display: flex;
+  }
+
+  .site-nav a,
+  .site-nav .search-icon {
+    width: 100%;
+    padding-left: 0;
+  }
+
+  .site-nav .search-icon {
+    text-align: left;
+    margin-left: 0;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- replace the desktop-only header on every page with an accessible hamburger toggle that exposes the navigation on smaller screens
- add reusable JavaScript to collapse the menu after selection and when returning to desktop breakpoints
- style the banner and navigation so the drawer renders cleanly on mobile while preserving the desktop layout

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d4cafc51ac8332a35956f971d5a412